### PR TITLE
Use GITHUB_TOKEN to read packages in CI job

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      packages: read
       security-events: write
     strategy:
       fail-fast: false
@@ -39,7 +40,7 @@ jobs:
       - name: Build
         run: ./gradlew build
         env:
-          MULTI_PACKAGES_TOKEN: ${{ secrets.MULTI_PACKAGES_TOKEN }}
-          MULTI_PACKAGES_USER: ${{ secrets.MULTI_PACKAGES_USER }}
+          MULTI_PACKAGES_TOKEN: ${{ env.GITHUB_ACTOR }}
+          MULTI_PACKAGES_USER: ${{ secrets.GITHUB_TOKEN }}
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
We don't have access to repository secrets in pull requests, but since we only need read access to a public package we can use the standard GITHUB_TOKEN.