### PR TITLE
test(integration): Smoke tests for handlers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.2'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
 }
 
 bootRun {

--- a/src/main/java/io/apimap/api/repository/mongodb/MongoRESTConverter.java
+++ b/src/main/java/io/apimap/api/repository/mongodb/MongoRESTConverter.java
@@ -71,7 +71,7 @@ public class MongoRESTConverter implements IRESTConverter {
     public Mono<IApiVersion> decodeApiVersion(final IApi api, final JsonApiRestRequestWrapper<ApiVersionDataRestEntity> object) {
         return Mono.just(new ApiVersion(
                 object.getData().getVersion(),
-                object.getData().getCreated().toInstant(),
+                object.getData().getCreated() != null ? object.getData().getCreated().toInstant() : null,
                 api.getId()
         ));
     }

--- a/src/main/java/io/apimap/api/repository/nitrite/NitriteMetadataRepository.java
+++ b/src/main/java/io/apimap/api/repository/nitrite/NitriteMetadataRepository.java
@@ -105,8 +105,7 @@ public class NitriteMetadataRepository extends NitriteRepository implements IMet
 
     public Mono<Boolean> delete(String apiId) {
         ObjectRepository<Metadata> repository = database.getRepository(Metadata.class);
-        repository.remove(eq("apiId", apiId));
-        return Mono.empty();
+        return Mono.just(repository.remove(eq("apiId", apiId)).getAffectedCount() > 0);
     }
 
     public Mono<Boolean> delete(String apiId, String version) {

--- a/src/main/java/io/apimap/api/repository/nitrite/NitriteRESTConverter.java
+++ b/src/main/java/io/apimap/api/repository/nitrite/NitriteRESTConverter.java
@@ -53,7 +53,7 @@ public class NitriteRESTConverter implements IRESTConverter {
         return Mono.just(
             new ApiVersion(
                 object.getData().getVersion(),
-                object.getData().getCreated().toInstant(),
+                object.getData().getCreated() != null ? object.getData().getCreated().toInstant() : null,
                 api.getId()
             )
         );

--- a/src/main/java/io/apimap/api/service/ApiResourceService.java
+++ b/src/main/java/io/apimap/api/service/ApiResourceService.java
@@ -273,8 +273,8 @@ public class ApiResourceService {
         return apiRepository
                 .get(context.getApiName())
                 .flatMap(api -> classificationRepository.delete(((IApi) api).getId())
-                        .zipWith(metadataRepository.delete(((IApi) api).getId()), (previous, current) -> (Boolean) previous && ((Boolean) current).booleanValue())
-                        .zipWith(apiRepository.delete(((IApi) api).getName()), (previous, current) -> (Boolean) previous && ((Boolean) current).booleanValue()))
+                        .zipWith(metadataRepository.delete(((IApi) api).getId()), (previous, current) -> (Boolean) previous || ((Boolean) current).booleanValue())
+                        .zipWith(apiRepository.delete(((IApi) api).getName()), (previous, current) -> (Boolean) previous || ((Boolean) current).booleanValue()))
                 .filter(value -> (Boolean) value)
                 .flatMap(result -> ResponseBuilder
                         .builder(startTime, apimapConfiguration)

--- a/src/test/java/io/apimap/api/integration/IntegrationTestHelper.java
+++ b/src/test/java/io/apimap/api/integration/IntegrationTestHelper.java
@@ -1,0 +1,144 @@
+package io.apimap.api.integration;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.apimap.api.repository.interfaces.IApi;
+import io.apimap.api.repository.interfaces.IApiVersion;
+import io.apimap.api.repository.repository.IApiRepository;
+import io.apimap.api.rest.ApiCollectionRootRestEntity;
+import io.apimap.api.rest.ApiDataRestEntity;
+import io.apimap.api.rest.ApiVersionDataRestEntity;
+import io.apimap.api.rest.MetadataDataRestEntity;
+import io.apimap.api.rest.jsonapi.JsonApiRestRequestWrapper;
+import io.apimap.api.rest.jsonapi.JsonApiRestResponseWrapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.List;
+
+/**
+ * Helper class for making HTTP calls and setting up and clearing the database
+ */
+@Component
+class IntegrationTestHelper {
+    public static final ParameterizedTypeReference<JsonApiRestResponseWrapper<ApiDataRestEntity>> RESPONSE_TYPE_API = new ParameterizedTypeReference<>() {};
+    public static final ParameterizedTypeReference<JsonApiRestResponseWrapper<ApiCollectionRootRestEntity>> RESPONSE_TYPE_API_LIST = new ParameterizedTypeReference<>() {};
+    public static final ParameterizedTypeReference<JsonApiRestResponseWrapper<ApiVersionDataRestEntity>> RESPONSE_TYPE_VERSION = new ParameterizedTypeReference<>() {};
+    public static final ParameterizedTypeReference<JsonApiRestResponseWrapper<MetadataDataRestEntity>> RESPONSE_TYPE_METADATA = new ParameterizedTypeReference<>() {};
+
+    @Autowired
+    private WebTestClient webClient;
+
+    @Autowired
+    private IApiRepository apiRepository;
+
+    String currentApiToken;
+    ApiDataRestEntity currentApi;
+    ApiVersionDataRestEntity currentVersion;
+
+    @SuppressWarnings({"ConstantConditions"})
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
+    public void clearDatabases() {
+        var apis = (List<IApi>) apiRepository.all().collectList().block();
+        for (var api: apis) {
+            var versions = (List<IApiVersion>)apiRepository.allApiVersions(api.getId()).collectList().block();
+            for (var version: versions) {
+                apiRepository.deleteApiVersion(version.getApiId(), version.getVersion()).block();
+            }
+            apiRepository.delete(api.getName()).block();
+        }
+    }
+
+    /** Helper method to store an API and keep the token and API data for further update */
+    public ApiDataRestEntity storeApi(ApiDataRestEntity testApi) {
+        var postResult = postJsonPublic(RESPONSE_TYPE_API, new JsonApiRestRequestWrapper<>(testApi), "/api");
+        currentApi = postResult.getData();
+        currentApiToken = currentApi.getMeta().getToken();
+        return currentApi;
+    }
+
+    /** Helper method to add an API version to the last added API */
+    public ApiVersionDataRestEntity storeVersionForCurrentApi(ApiVersionDataRestEntity testVersion) {
+        var postResult = postJsonAuthed(RESPONSE_TYPE_VERSION, new JsonApiRestRequestWrapper<>(testVersion), "/api/{name}/version", currentApi.getName());
+        currentVersion = postResult.getData();
+        return currentVersion;
+    }
+
+    /** Helper method to add metadata */
+    public MetadataDataRestEntity storeMetadataForCurrentVersion(MetadataDataRestEntity testMetadata) {
+        return postJsonAuthed(
+                RESPONSE_TYPE_METADATA,
+                new JsonApiRestRequestWrapper<>(testMetadata),
+                "/api/{name}/version/{version}/metadata", currentApi.getName(), currentVersion.getVersion()
+        ).getData();
+    }
+
+    /** Helper for sending a GET request with no auth and receiving JSON in response */
+    public <T> T getJsonPublic(ParameterizedTypeReference<T> responseType, String uri, Object... uriVariables) {
+        return webClient.get().uri(uri, uriVariables)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .is2xxSuccessful()
+                .expectBody(responseType)
+                .returnResult()
+                .getResponseBody();
+    }
+
+    /** Helper for sending a POST request with no auth and receiving JSON in response */
+    public <T> T postJsonPublic(ParameterizedTypeReference<T> responseType, Object requestBody, String uri, Object... uriVariables) {
+        return webClient.post().uri(uri, uriVariables)
+                .bodyValue(requestBody)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .is2xxSuccessful()
+                .expectBody(responseType)
+                .returnResult()
+                .getResponseBody();
+    }
+
+    /** Helper for sending a POST request with auth for the last added API and receiving JSON in response */
+    public <T> T postJsonAuthed(ParameterizedTypeReference<T> responseType, Object requestBody, String uri, Object... uriVariables) {
+        return webClient.post().uri(uri, uriVariables)
+                .bodyValue(requestBody)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + currentApiToken)
+                .exchange()
+                .expectStatus()
+                .is2xxSuccessful()
+                .expectBody(responseType)
+                .returnResult()
+                .getResponseBody();
+    }
+
+    /** Helper for sending a PUT request with auth for the last added API and receiving JSON in response */
+    public <T> T putJsonAuthed(ParameterizedTypeReference<T> responseType, Object requestBody, String uri, Object... uriVariables) {
+        return webClient.put().uri(uri, uriVariables)
+                .bodyValue(requestBody)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + currentApiToken)
+                .exchange()
+                .expectStatus()
+                .is2xxSuccessful()
+                .expectBody(responseType)
+                .returnResult()
+                .getResponseBody();
+    }
+
+    /** Helper for sending a DELETE request with auth for the last added API */
+    public void deleteAuthedAndVerifyGone(String uri, Object... uriVariables) {
+        webClient.delete().uri(uri, uriVariables)
+                .header("Authorization", "Bearer " + currentApiToken)
+                .exchange()
+                .expectStatus().isNoContent();
+
+        // Verify that deleted resource returns 404 now
+        webClient.get().uri(uri, uriVariables)
+                .header("Authorization", "Bearer " + currentApiToken)
+                .exchange()
+                .expectStatus().isNotFound();
+    }
+}

--- a/src/test/java/io/apimap/api/integration/SmokeTestAllBase.java
+++ b/src/test/java/io/apimap/api/integration/SmokeTestAllBase.java
@@ -1,0 +1,179 @@
+package io.apimap.api.integration;
+
+import io.apimap.api.repository.interfaces.IApi;
+import io.apimap.api.repository.interfaces.IApiVersion;
+import io.apimap.api.repository.repository.*;
+import io.apimap.api.rest.*;
+import io.apimap.api.rest.jsonapi.JsonApiRestRequestWrapper;
+import io.apimap.api.rest.jsonapi.JsonApiRestResponseWrapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Base test class with common test cases that should work both when using NitriteDB and MongoDB
+ */
+public abstract class SmokeTestAllBase {
+
+    private static final ParameterizedTypeReference<JsonApiRestResponseWrapper<ApiDataRestEntity>> RESPONSE_TYPE_API = new ParameterizedTypeReference<>() {};
+    private static final ParameterizedTypeReference<JsonApiRestResponseWrapper<ApiCollectionRootRestEntity>> RESPONSE_TYPE_API_LIST = new ParameterizedTypeReference<>() {};
+    private static final ParameterizedTypeReference<JsonApiRestResponseWrapper<ApiVersionDataRestEntity>> RESPONSE_TYPE_VERSION = new ParameterizedTypeReference<>() {};
+    private static final ParameterizedTypeReference<JsonApiRestResponseWrapper<MetadataDataRestEntity>> RESPONSE_TYPE_METADATA = new ParameterizedTypeReference<>() {};
+
+    private final TestDataHelper testData = new TestDataHelper();
+
+    private String currentApiToken;
+    private ApiDataRestEntity currentApi;
+    private ApiVersionDataRestEntity currentVersion;
+
+    @Autowired
+    private WebTestClient webClient;
+
+    @Autowired
+    private IApiRepository apiRepository;
+    @Autowired
+    private IClassificationRepository classificationRepository;
+    @Autowired
+    private IMetadataRepository metadataRepository;
+    @Autowired
+    private ITaxonomyRepository taxonomyRepository;
+    @Autowired
+    private IVoteRepository voteRepository;
+
+    @SuppressWarnings({"ConstantConditions"})
+    @AfterEach
+    public void clearDatabases() {
+        var apis = (List<IApi>) apiRepository.all().collectList().block();
+        for (var api: apis) {
+            var versions = (List<IApiVersion>)apiRepository.allApiVersions(api.getId()).collectList().block();
+            for (var version: versions) {
+                apiRepository.deleteApiVersion(version.getApiId(), version.getVersion()).block();
+            }
+            apiRepository.delete(api.getName()).block();
+            System.err.println("deleted " + api);
+        }
+    }
+
+    @Test
+    public void rootShouldReturnOk() throws Exception {
+        webClient.get().uri("/")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .is2xxSuccessful();
+    }
+
+    @Test
+    public void postAndRetrieveAPI() throws Exception {
+        var testApi = testData.createApiData();
+
+        var postResult = webClient.post().uri("/api")
+                .bodyValue(new JsonApiRestRequestWrapper<>(testApi))
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .is2xxSuccessful()
+                .expectBody(RESPONSE_TYPE_API)
+                .returnResult()
+                .getResponseBody();
+
+        var createdApi = postResult.getData();
+        assertThat(createdApi)
+                .usingRecursiveComparison()
+                .ignoringFields("meta", "relationships")
+                .isEqualTo(testApi);
+
+        assertThat(createdApi.getMeta().getToken()).as("token")
+                .isNotEmpty();
+
+        var getResult = webClient.get().uri("/api/{name}", testApi.getName())
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().is2xxSuccessful()
+                .expectBody(RESPONSE_TYPE_API)
+                .returnResult()
+                .getResponseBody();
+
+        assertThat(getResult.getData())
+                .usingRecursiveComparison()
+                .ignoringFields("relationships")
+                .isEqualTo(testApi);
+    }
+
+    @Test
+    public void testGetAllApis() {
+        // APIs need a version with metadata to be listed
+        storeApi(testData.createApiData());
+        storeVersionForCurrentApi(testData.createApiVersion());
+        storeMetadataForCurrentVersion(testData.createMetadata());
+
+        var getResult = webClient.get().uri("/api")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().is2xxSuccessful()
+                .expectBody(RESPONSE_TYPE_API_LIST)
+                .returnResult()
+                .getResponseBody();
+
+        assertThat(getResult.getData().getData())
+                .hasSize(1);
+    }
+
+
+    /** Helper method to store an API and keep the token and API data for further update */
+    private ApiDataRestEntity storeApi(ApiDataRestEntity testApi) {
+        var postResult = webClient.post().uri("/api")
+                .bodyValue(new JsonApiRestRequestWrapper<>(testApi))
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .is2xxSuccessful()
+                .expectBody(RESPONSE_TYPE_API)
+                .returnResult()
+                .getResponseBody();
+
+        currentApi = postResult.getData();
+        currentApiToken = currentApi.getMeta().getToken();
+        return currentApi;
+    }
+
+    /** Helper method to add an API version to the last added API */
+    private ApiVersionDataRestEntity storeVersionForCurrentApi(ApiVersionDataRestEntity testVersion) {
+        var postResult = webClient.post().uri("/api/{name}/version", currentApi.getName())
+                .bodyValue(new JsonApiRestRequestWrapper<>(testVersion))
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + currentApiToken)
+                .exchange()
+                .expectStatus()
+                .is2xxSuccessful()
+                .expectBody(RESPONSE_TYPE_VERSION)
+                .returnResult()
+                .getResponseBody();
+
+        currentVersion = postResult.getData();
+        return currentVersion;
+    }
+
+    /** Helper method to add metadata */
+    private MetadataDataRestEntity storeMetadataForCurrentVersion(MetadataDataRestEntity testMetadata) {
+        var postResult = webClient.post().uri("/api/{name}/version/{version}/metadata", currentApi.getName(), currentVersion.getVersion())
+                .bodyValue(new JsonApiRestRequestWrapper<>(testMetadata))
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + currentApiToken)
+                .exchange()
+                .expectStatus()
+                .is2xxSuccessful()
+                .expectBody(RESPONSE_TYPE_METADATA)
+                .returnResult()
+                .getResponseBody();
+
+        return postResult.getData();
+    }
+}

--- a/src/test/java/io/apimap/api/integration/SmokeTestAllBase.java
+++ b/src/test/java/io/apimap/api/integration/SmokeTestAllBase.java
@@ -1,5 +1,6 @@
 package io.apimap.api.integration;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.apimap.api.repository.interfaces.IApi;
 import io.apimap.api.repository.interfaces.IApiVersion;
 import io.apimap.api.repository.repository.*;
@@ -48,6 +49,7 @@ public abstract class SmokeTestAllBase {
     private IVoteRepository voteRepository;
 
     @SuppressWarnings({"ConstantConditions"})
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     @AfterEach
     public void clearDatabases() {
         var apis = (List<IApi>) apiRepository.all().collectList().block();
@@ -57,7 +59,6 @@ public abstract class SmokeTestAllBase {
                 apiRepository.deleteApiVersion(version.getApiId(), version.getVersion()).block();
             }
             apiRepository.delete(api.getName()).block();
-            System.err.println("deleted " + api);
         }
     }
 

--- a/src/test/java/io/apimap/api/integration/SmokeTestAllBase.java
+++ b/src/test/java/io/apimap/api/integration/SmokeTestAllBase.java
@@ -1,21 +1,15 @@
 package io.apimap.api.integration;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.apimap.api.repository.interfaces.IApi;
-import io.apimap.api.repository.interfaces.IApiVersion;
-import io.apimap.api.repository.repository.*;
-import io.apimap.api.rest.*;
+import io.apimap.api.rest.ApiDataRestEntity;
 import io.apimap.api.rest.jsonapi.JsonApiRestRequestWrapper;
-import io.apimap.api.rest.jsonapi.JsonApiRestResponseWrapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-import java.util.List;
-
+import static io.apimap.api.integration.IntegrationTestHelper.RESPONSE_TYPE_API;
+import static io.apimap.api.integration.IntegrationTestHelper.RESPONSE_TYPE_API_LIST;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -23,43 +17,18 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public abstract class SmokeTestAllBase {
 
-    private static final ParameterizedTypeReference<JsonApiRestResponseWrapper<ApiDataRestEntity>> RESPONSE_TYPE_API = new ParameterizedTypeReference<>() {};
-    private static final ParameterizedTypeReference<JsonApiRestResponseWrapper<ApiCollectionRootRestEntity>> RESPONSE_TYPE_API_LIST = new ParameterizedTypeReference<>() {};
-    private static final ParameterizedTypeReference<JsonApiRestResponseWrapper<ApiVersionDataRestEntity>> RESPONSE_TYPE_VERSION = new ParameterizedTypeReference<>() {};
-    private static final ParameterizedTypeReference<JsonApiRestResponseWrapper<MetadataDataRestEntity>> RESPONSE_TYPE_METADATA = new ParameterizedTypeReference<>() {};
 
     private final TestDataHelper testData = new TestDataHelper();
-
-    private String currentApiToken;
-    private ApiDataRestEntity currentApi;
-    private ApiVersionDataRestEntity currentVersion;
 
     @Autowired
     private WebTestClient webClient;
 
     @Autowired
-    private IApiRepository apiRepository;
-    @Autowired
-    private IClassificationRepository classificationRepository;
-    @Autowired
-    private IMetadataRepository metadataRepository;
-    @Autowired
-    private ITaxonomyRepository taxonomyRepository;
-    @Autowired
-    private IVoteRepository voteRepository;
+    IntegrationTestHelper helper;
 
-    @SuppressWarnings({"ConstantConditions"})
-    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     @AfterEach
     public void clearDatabases() {
-        var apis = (List<IApi>) apiRepository.all().collectList().block();
-        for (var api: apis) {
-            var versions = (List<IApiVersion>)apiRepository.allApiVersions(api.getId()).collectList().block();
-            for (var version: versions) {
-                apiRepository.deleteApiVersion(version.getApiId(), version.getVersion()).block();
-            }
-            apiRepository.delete(api.getName()).block();
-        }
+        helper.clearDatabases();
     }
 
     @Test
@@ -77,11 +46,11 @@ public abstract class SmokeTestAllBase {
         var testApi = testData.createApiData();
         var apiUpdate = new ApiDataRestEntity(testApi.getName(), "http://example.org/new_repo");
 
-        var createResult = postJsonPublic(RESPONSE_TYPE_API, new JsonApiRestRequestWrapper<>(testApi), "/api");
-        currentApiToken = createResult.getData().getMeta().getToken();
-        var updateResult = putJsonAuthed(RESPONSE_TYPE_API, new JsonApiRestRequestWrapper<>(apiUpdate), "/api/{name}", testApi.getName());
-        var retrieveResult = getJsonPublic(RESPONSE_TYPE_API, "/api/{name}", testApi.getName());
-        deleteAuthedAndVerifyGone("/api/{name}", testApi.getName());
+        var createResult = helper.postJsonPublic(RESPONSE_TYPE_API, new JsonApiRestRequestWrapper<>(testApi), "/api");
+        helper.currentApiToken = createResult.getData().getMeta().getToken();
+        var updateResult = helper.putJsonAuthed(RESPONSE_TYPE_API, new JsonApiRestRequestWrapper<>(apiUpdate), "/api/{name}", testApi.getName());
+        var retrieveResult = helper.getJsonPublic(RESPONSE_TYPE_API, "/api/{name}", testApi.getName());
+        helper.deleteAuthedAndVerifyGone("/api/{name}", testApi.getName());
 
         assertThat(createResult.getData()).as("create result")
                 .usingRecursiveComparison()
@@ -110,105 +79,13 @@ public abstract class SmokeTestAllBase {
     @Test
     public void testGetAllApis() {
         // APIs need a version with metadata to be listed
-        storeApi(testData.createApiData());
-        storeVersionForCurrentApi(testData.createApiVersion());
-        storeMetadataForCurrentVersion(testData.createMetadata());
+        helper.storeApi(testData.createApiData());
+        helper.storeVersionForCurrentApi(testData.createApiVersion());
+        helper.storeMetadataForCurrentVersion(testData.createMetadata());
 
-        var getResult = getJsonPublic(RESPONSE_TYPE_API_LIST, "/api");
+        var getResult = helper.getJsonPublic(RESPONSE_TYPE_API_LIST, "/api");
 
         assertThat(getResult.getData().getData())
                 .hasSize(1);
-    }
-
-
-    /** Helper method to store an API and keep the token and API data for further update */
-    private ApiDataRestEntity storeApi(ApiDataRestEntity testApi) {
-        var postResult = postJsonPublic(RESPONSE_TYPE_API, new JsonApiRestRequestWrapper<>(testApi), "/api");
-        currentApi = postResult.getData();
-        currentApiToken = currentApi.getMeta().getToken();
-        return currentApi;
-    }
-
-    /** Helper method to add an API version to the last added API */
-    private ApiVersionDataRestEntity storeVersionForCurrentApi(ApiVersionDataRestEntity testVersion) {
-        var postResult = postJsonAuthed(RESPONSE_TYPE_VERSION, new JsonApiRestRequestWrapper<>(testVersion), "/api/{name}/version", currentApi.getName());
-        currentVersion = postResult.getData();
-        return currentVersion;
-    }
-
-    /** Helper method to add metadata */
-    private MetadataDataRestEntity storeMetadataForCurrentVersion(MetadataDataRestEntity testMetadata) {
-        return postJsonAuthed(
-                RESPONSE_TYPE_METADATA,
-                new JsonApiRestRequestWrapper<>(testMetadata),
-                "/api/{name}/version/{version}/metadata", currentApi.getName(), currentVersion.getVersion()
-        ).getData();
-    }
-
-    /** Helper for sending a GET request with no auth and receiving JSON in response */
-    private <T> T getJsonPublic(ParameterizedTypeReference<T> responseType, String uri, Object... uriVariables) {
-        return webClient.get().uri(uri, uriVariables)
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus()
-                .is2xxSuccessful()
-                .expectBody(responseType)
-                .returnResult()
-                .getResponseBody();
-    }
-
-    /** Helper for sending a POST request with no auth and receiving JSON in response */
-    private <T> T postJsonPublic(ParameterizedTypeReference<T> responseType, Object requestBody, String uri, Object... uriVariables) {
-        return webClient.post().uri(uri, uriVariables)
-                .bodyValue(requestBody)
-                .accept(MediaType.APPLICATION_JSON)
-                .exchange()
-                .expectStatus()
-                .is2xxSuccessful()
-                .expectBody(responseType)
-                .returnResult()
-                .getResponseBody();
-    }
-
-    /** Helper for sending a POST request with auth for the last added API and receiving JSON in response */
-    private <T> T postJsonAuthed(ParameterizedTypeReference<T> responseType, Object requestBody, String uri, Object... uriVariables) {
-        return webClient.post().uri(uri, uriVariables)
-                .bodyValue(requestBody)
-                .accept(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + currentApiToken)
-                .exchange()
-                .expectStatus()
-                .is2xxSuccessful()
-                .expectBody(responseType)
-                .returnResult()
-                .getResponseBody();
-    }
-
-    /** Helper for sending a PUT request with auth for the last added API and receiving JSON in response */
-    private <T> T putJsonAuthed(ParameterizedTypeReference<T> responseType, Object requestBody, String uri, Object... uriVariables) {
-        return webClient.put().uri(uri, uriVariables)
-                .bodyValue(requestBody)
-                .accept(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + currentApiToken)
-                .exchange()
-                .expectStatus()
-                .is2xxSuccessful()
-                .expectBody(responseType)
-                .returnResult()
-                .getResponseBody();
-    }
-
-    /** Helper for sending a DELETE request with auth for the last added API */
-    private void deleteAuthedAndVerifyGone(String uri, Object... uriVariables) {
-        webClient.delete().uri(uri, uriVariables)
-                .header("Authorization", "Bearer " + currentApiToken)
-                .exchange()
-                .expectStatus().isNoContent();
-
-        // Verify that deleted resource returns 404 now
-        webClient.get().uri(uri, uriVariables)
-                .header("Authorization", "Bearer " + currentApiToken)
-                .exchange()
-                .expectStatus().isNotFound();
     }
 }

--- a/src/test/java/io/apimap/api/integration/SmokeTestAllWithNitriteIT.java
+++ b/src/test/java/io/apimap/api/integration/SmokeTestAllWithNitriteIT.java
@@ -1,0 +1,20 @@
+package io.apimap.api.integration;
+
+import io.apimap.api.integration.dbconfig.NitriteTestConfig;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Run smoke tests with the Nitrite database implementations
+ */
+@SpringBootTest
+@AutoConfigureWebTestClient
+@Import(NitriteTestConfig.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SmokeTestAllWithNitriteIT extends SmokeTestAllBase {
+
+    // Runs tests from the SmokeTestAllBase base class
+
+}

--- a/src/test/java/io/apimap/api/integration/TestDataHelper.java
+++ b/src/test/java/io/apimap/api/integration/TestDataHelper.java
@@ -1,0 +1,45 @@
+package io.apimap.api.integration;
+
+import io.apimap.api.rest.ApiDataRestEntity;
+import io.apimap.api.rest.ApiVersionDataRestEntity;
+import io.apimap.api.rest.ApiVersionRatingEntity;
+import io.apimap.api.rest.MetadataDataRestEntity;
+
+import java.util.Date;
+import java.util.List;
+
+/** Helper to generate dummy test data */
+public class TestDataHelper {
+    public ApiDataRestEntity createApiData() {
+        return new ApiDataRestEntity(
+                "test-api",
+                "https://example.org/code-repository"
+        );
+    }
+
+    public ApiVersionDataRestEntity createApiVersion() {
+        return new ApiVersionDataRestEntity(
+                "v1.1",
+                new Date(),
+                new ApiVersionRatingEntity(5),
+                "https://example.org/my-api/v1"
+        );
+    }
+
+    public MetadataDataRestEntity createMetadata() {
+        return new MetadataDataRestEntity(
+                "test-api",
+                "A test API for doing tests.",
+                "EXTREMELY VISIBLE",
+                "v1.1",
+                "eternal beta",
+                "JSON:API v1.1",
+                "napkin scribbles",
+                "middle-end",
+                "postal department",
+                "S19999",
+                List.of("https://example.org/README.txt"),
+                "https://example.org/api"
+        );
+    }
+}

--- a/src/test/java/io/apimap/api/integration/dbconfig/NitriteTestConfig.java
+++ b/src/test/java/io/apimap/api/integration/dbconfig/NitriteTestConfig.java
@@ -1,0 +1,18 @@
+package io.apimap.api.integration.dbconfig;
+
+import io.apimap.api.configuration.NitriteConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+/**
+ * Nitrite configuration for tests - simply returns an empty filename to set up an in-memory NitriteDB instance
+ */
+@TestConfiguration
+public class NitriteTestConfig {
+    @Bean
+    @Primary
+    public NitriteConfiguration getConfig() {
+        return new NitriteConfiguration();
+    }
+}


### PR DESCRIPTION
Start on smoke tests using the Nitrite database for now, should be extendable to run towards MongoDB path as well.

