### PR TITLE
fix(apis): Integration test coverage for API routes

### DIFF
--- a/src/main/java/io/apimap/api/repository/mongodb/MongoDBVoteRepository.java
+++ b/src/main/java/io/apimap/api/repository/mongodb/MongoDBVoteRepository.java
@@ -56,4 +56,14 @@ public class MongoDBVoteRepository extends MongoDBRepository implements IVoteRep
                 .take(1)
                 .single(-1);
     }
+
+    @Override
+    public Mono<Boolean> delete(String apiId, String apiVersion) {
+        final Query query = new Query()
+                .addCriteria(Criteria.where("apiId").is(apiId))
+                .addCriteria(Criteria.where("apiVersion").is(apiVersion));
+
+        return template.remove(query, Vote.class)
+                .map(result -> result.getDeletedCount() > 0);
+    }
 }

--- a/src/main/java/io/apimap/api/repository/nitrite/NitriteVoteRepository.java
+++ b/src/main/java/io/apimap/api/repository/nitrite/NitriteVoteRepository.java
@@ -58,4 +58,12 @@ public class NitriteVoteRepository extends NitriteRepository implements IVoteRep
 
         return Mono.just(Double.valueOf(average).intValue());
     }
+
+    @Override
+    public Mono<Boolean> delete(String apiId, String apiVersion) {
+        final ObjectRepository<Vote> repository = database.getRepository(Vote.class);
+        return Mono.just(repository.remove(
+                and(eq("apiId", apiId), eq("apiVersion", apiVersion))
+        ).getAffectedCount() > 0);
+    }
 }

--- a/src/main/java/io/apimap/api/repository/repository/IVoteRepository.java
+++ b/src/main/java/io/apimap/api/repository/repository/IVoteRepository.java
@@ -9,4 +9,5 @@ public interface IVoteRepository <TIVote extends IVote> {
     Flux<TIVote> all(String apiId, String apiVersion);
     Mono<TIVote> add(TIVote entity);
     Mono<Integer> rating(String apiId, String apiVersion);
+    Mono<Boolean> delete(String apiId, String apiVersion);
 }

--- a/src/main/java/io/apimap/api/service/ApiMetadataService.java
+++ b/src/main/java/io/apimap/api/service/ApiMetadataService.java
@@ -100,8 +100,7 @@ public class ApiMetadataService {
                             return Mono.justOrEmpty(metadata);
                         })
                 )
-                .flatMap(metadata -> metadataRepository.update((IMetadata) metadata)
-                        .switchIfEmpty(metadataRepository.add((IMetadata) metadata)))
+                .flatMap(metadata -> metadataRepository.update((IMetadata) metadata))
                 .flatMap(metadata -> entityMapper.encodeMetadata(uri, (IMetadata) metadata))
                 .flatMap(version -> ResponseBuilder
                         .builder(startTime, apimapConfiguration)

--- a/src/main/java/io/apimap/api/service/ApiResourceService.java
+++ b/src/main/java/io/apimap/api/service/ApiResourceService.java
@@ -372,8 +372,8 @@ public class ApiResourceService {
         return apiRepository
                 .get(context.getApiName())
                 .flatMap(api -> classificationRepository.delete(((IApi) api).getId(), context.getApiVersion())
-                        .zipWith(metadataRepository.delete(((IApi) api).getId(), context.getApiVersion()), (previous, current) -> (Boolean) previous && ((Boolean) current).booleanValue())
-                        .zipWith(apiRepository.deleteApiVersion(((IApi) api).getId(), context.getApiVersion()), (previous, current) -> (Boolean) previous && ((Boolean) current).booleanValue()))
+                        .zipWith(metadataRepository.delete(((IApi) api).getId(), context.getApiVersion()), (previous, current) -> (Boolean) previous || ((Boolean) current).booleanValue())
+                        .zipWith(apiRepository.deleteApiVersion(((IApi) api).getId(), context.getApiVersion()), (previous, current) -> (Boolean) previous || ((Boolean) current).booleanValue()))
                 .filter(value -> (Boolean) value)
                 .flatMap(result -> ResponseBuilder
                         .builder(startTime, apimapConfiguration)

--- a/src/main/java/io/apimap/api/service/ApiResourceService.java
+++ b/src/main/java/io/apimap/api/service/ApiResourceService.java
@@ -22,6 +22,7 @@ package io.apimap.api.service;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.apimap.api.configuration.ApimapConfiguration;
 import io.apimap.api.repository.IRESTConverter;
@@ -118,6 +119,7 @@ public class ApiResourceService {
                 .switchIfEmpty(Mono.defer(() -> ServerResponse.noContent().build()));
     }
 
+    @SuppressFBWarnings(value = "OS_OPEN_STREAM", justification = "in-memory buffers, can be GCed just fine")
     @NotNull
     @PreAuthorize("@Authorizer.isValidAccessToken(#request)")
     public Mono<ServerResponse> allApisZip(final ServerRequest request){
@@ -126,69 +128,78 @@ public class ApiResourceService {
 
         ReentrantLock lock = new ReentrantLock();
 
-        try(ZipOutputStream zipOutputStream = new ZipOutputStream(dataBuffer.asOutputStream())){
-            ObjectMapper mapper = new ObjectMapper();
-            mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        ObjectMapper mapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 
-            return Mono.when(
-                            apiRepository
-                                    .all()
-                                    .collectList()
-                                    .publishOn(Schedulers.boundedElastic())
-                                    .doOnNext(collection -> {
-                                        try {
-                                            lock.lock();
-                                            zipOutputStream.putNextEntry(new ZipEntry("apis.json"));
-                                            zipOutputStream.write(mapper.writeValueAsBytes(collection));
-                                            zipOutputStream.closeEntry();
-                                        } catch (IOException ignored) {
-                                        } finally {
-                                            lock.unlock();
-                                        }
-                                    }),
-                            classificationRepository
-                                    .all()
-                                    .collectList()
-                                    .publishOn(Schedulers.boundedElastic())
-                                    .doOnNext(collection -> {
-                                        try {
-                                            lock.lock();
-                                            zipOutputStream.putNextEntry(new ZipEntry("classifications.json"));
-                                            zipOutputStream.write(mapper.writeValueAsBytes(collection));
-                                            zipOutputStream.closeEntry();
-                                        } catch (IOException ignored) {
-                                        } finally {
-                                            lock.unlock();
-                                        }
-                                    }),
-                            metadataRepository
-                                    .all()
-                                    .collectList()
-                                    .publishOn(Schedulers.boundedElastic())
-                                    .doOnNext(collection -> {
-                                        try {
-                                            lock.lock();
-                                            zipOutputStream.putNextEntry(new ZipEntry("metadata.json"));
-                                            zipOutputStream.write(mapper.writeValueAsBytes(collection));
-                                            zipOutputStream.closeEntry();
-                                        } catch (IOException ignored) {
-                                        } finally {
-                                            lock.unlock();
-                                        }
-                                    })
-                    )
-                    .thenReturn(Boolean.TRUE)
-                    .publishOn(Schedulers.boundedElastic())
-                    .flatMap(status ->
-                          ServerResponse.status(HttpStatus.OK)
+        ZipOutputStream zipOutputStream = new ZipOutputStream(dataBuffer.asOutputStream());
+        return Mono.when(
+                        apiRepository
+                                .all()
+                                .collectList()
+                                .publishOn(Schedulers.boundedElastic())
+                                .doOnNext(collection -> {
+                                    try {
+                                        lock.lock();
+                                        zipOutputStream.putNextEntry(new ZipEntry("apis.json"));
+                                        zipOutputStream.write(mapper.writeValueAsBytes(collection));
+                                        zipOutputStream.closeEntry();
+                                    } catch (IOException e) {
+                                        LOGGER.warn("failed to serialize APIs", e);
+                                    } finally {
+                                        lock.unlock();
+                                    }
+                                }),
+                        classificationRepository
+                                .all()
+                                .collectList()
+                                .publishOn(Schedulers.boundedElastic())
+                                .doOnNext(collection -> {
+                                    try {
+                                        lock.lock();
+                                        zipOutputStream.putNextEntry(new ZipEntry("classifications.json"));
+                                        zipOutputStream.write(mapper.writeValueAsBytes(collection));
+                                        zipOutputStream.closeEntry();
+                                    } catch (IOException e) {
+                                        LOGGER.warn("failed to serialize classifications", e);
+                                    } finally {
+                                        lock.unlock();
+                                    }
+                                }),
+                        metadataRepository
+                                .all()
+                                .collectList()
+                                .publishOn(Schedulers.boundedElastic())
+                                .doOnNext(collection -> {
+                                    try {
+                                        lock.lock();
+                                        zipOutputStream.putNextEntry(new ZipEntry("metadata.json"));
+                                        zipOutputStream.write(mapper.writeValueAsBytes(collection));
+                                        zipOutputStream.closeEntry();
+                                    } catch (IOException e) {
+                                        LOGGER.warn("failed to serialize metadata", e);
+                                    } finally {
+                                        lock.unlock();
+                                    }
+                                })
+                )
+                .thenReturn(Boolean.TRUE)
+                .publishOn(Schedulers.boundedElastic())
+                .flatMap(status -> {
+                    try {
+                        zipOutputStream.finish();
+                        zipOutputStream.close();
+                        return ServerResponse.status(HttpStatus.OK)
                                 .header("Access-Control-Allow-Origin", "*")
                                 .header("Access-Control-Request-Method", "GET")
                                 .contentType(new MediaType("application", "zip"))
-                                .body(Mono.just(dataBuffer), DataBuffer.class)
-                    );
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+                                .body(Mono.just(dataBuffer), DataBuffer.class);
+                    } catch (IOException e) {
+                        LOGGER.warn("Error creating ZIP", e);
+                        return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                                .bodyValue("Error creating ZIP");
+                    }
+                });
     }
 
     @NotNull
@@ -270,6 +281,7 @@ public class ApiResourceService {
 
         final ApiContext context = RequestUtil.apiContextFromRequest(request);
 
+        // TOOD: not deleting API versions?
         return apiRepository
                 .get(context.getApiName())
                 .flatMap(api -> classificationRepository.delete(((IApi) api).getId())
@@ -345,6 +357,7 @@ public class ApiResourceService {
         final JavaType type = new ObjectMapper().getTypeFactory().constructParametricType(JsonApiRestRequestWrapper.class, ApiVersionDataRestEntity.class);
         final ApiContext context = RequestUtil.apiContextFromRequest(request);
 
+        // FIXME: better error message here - e.g. if you forget the created field
         return request
                 .bodyToMono(ParameterizedTypeReference.forType(type))
                 .filter(Objects::nonNull)

--- a/src/test/java/io/apimap/api/integration/IntegrationTestHelper.java
+++ b/src/test/java/io/apimap/api/integration/IntegrationTestHelper.java
@@ -166,4 +166,44 @@ class IntegrationTestHelper {
                 .exchange()
                 .expectStatus().isNotFound();
     }
+
+    /** Helper for sending a GET request with no auth and receiving Markdown in response */
+    public String getMarkdownPublic(String uri, Object... uriVariables) {
+        return webClient.get().uri(uri, uriVariables)
+                .accept(MediaType.TEXT_MARKDOWN)
+                .exchange()
+                .expectStatus()
+                .is2xxSuccessful()
+                .expectBody(String.class)
+                .returnResult()
+                .getResponseBody();
+    }
+
+    /** Helper for sending a POST request with auth for the last added API and receiving Markdown in response */
+    public String postMarkdownAuthed(String requestBody, String uri, Object... uriVariables) {
+        return webClient.post().uri(uri, uriVariables)
+                .contentType(MediaType.TEXT_MARKDOWN)
+                .bodyValue(requestBody)
+                .header("Authorization", "Bearer " + currentApiToken)
+                .exchange()
+                .expectStatus()
+                .is2xxSuccessful()
+                .expectBody(String.class)
+                .returnResult()
+                .getResponseBody();
+    }
+
+    /** Helper for sending a PUT request with auth for the last added API and receiving Markdown in response */
+    public String putMarkdownAuthed(String requestBody, String uri, Object... uriVariables) {
+        return webClient.put().uri(uri, uriVariables)
+                .contentType(MediaType.TEXT_MARKDOWN)
+                .bodyValue(requestBody)
+                .header("Authorization", "Bearer " + currentApiToken)
+                .exchange()
+                .expectStatus()
+                .is2xxSuccessful()
+                .expectBody(String.class)
+                .returnResult()
+                .getResponseBody();
+    }
 }

--- a/src/test/java/io/apimap/api/integration/IntegrationTestHelper.java
+++ b/src/test/java/io/apimap/api/integration/IntegrationTestHelper.java
@@ -3,9 +3,11 @@ package io.apimap.api.integration;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.apimap.api.repository.interfaces.IApi;
 import io.apimap.api.repository.interfaces.IApiVersion;
+import io.apimap.api.repository.interfaces.IDocument;
 import io.apimap.api.repository.repository.IApiRepository;
 import io.apimap.api.repository.repository.IClassificationRepository;
 import io.apimap.api.repository.repository.IMetadataRepository;
+import io.apimap.api.repository.repository.IVoteRepository;
 import io.apimap.api.rest.*;
 import io.apimap.api.rest.jsonapi.JsonApiRestRequestWrapper;
 import io.apimap.api.rest.jsonapi.JsonApiRestResponseWrapper;
@@ -28,6 +30,8 @@ class IntegrationTestHelper {
     public static final ParameterizedTypeReference<JsonApiRestResponseWrapper<ApiVersionCollectionRootRestEntity>> RESPONSE_TYPE_VERSION_LIST = new ParameterizedTypeReference<>() {};
     public static final ParameterizedTypeReference<JsonApiRestResponseWrapper<ClassificationRootRestEntity>> RESPONSE_TYPE_CLASSIFICATION_LIST = new ParameterizedTypeReference<>() {};
     public static final ParameterizedTypeReference<JsonApiRestResponseWrapper<MetadataDataRestEntity>> RESPONSE_TYPE_METADATA = new ParameterizedTypeReference<>() {};
+    public static final ParameterizedTypeReference<JsonApiRestResponseWrapper<VoteDataRestEntity>> RESPONSE_TYPE_VOTE = new ParameterizedTypeReference<>() {};
+    public static final ParameterizedTypeReference<JsonApiRestResponseWrapper<VoteRootRestEntity>> RESPONSE_TYPE_VOTE_LIST = new ParameterizedTypeReference<>() {};
 
     @Autowired
     private WebTestClient webClient;
@@ -38,6 +42,8 @@ class IntegrationTestHelper {
     private IMetadataRepository metadataRepository;
     @Autowired
     private IClassificationRepository classificationRepository;
+    @Autowired
+    private IVoteRepository voteRepository;
 
     String currentApiToken;
     ApiDataRestEntity currentApi;
@@ -61,10 +67,17 @@ class IntegrationTestHelper {
                     System.err.println("Could not delete test metadata: " + e);
                 }
                 try {
+                    metadataRepository.deleteDocument(version.getApiId(), version.getVersion(), IDocument.DocumentType.README).block();
+                    metadataRepository.deleteDocument(version.getApiId(), version.getVersion(), IDocument.DocumentType.CHANGELOG).block();
+                } catch (Exception e) {
+                    System.err.println("Could not delete test documents: " + e);
+                }
+                try {
                     apiRepository.deleteApiVersion(version.getApiId(), version.getVersion()).block();
                 } catch (Exception e) {
                     System.err.println("Could not delete test API version: " + e);
                 }
+                // TODO: delete votes
             }
             apiRepository.delete(api.getName()).block();
         }

--- a/src/test/java/io/apimap/api/integration/IntegrationTestHelper.java
+++ b/src/test/java/io/apimap/api/integration/IntegrationTestHelper.java
@@ -223,4 +223,16 @@ class IntegrationTestHelper {
                 .returnResult()
                 .getResponseBody();
     }
+
+    /** Helper for sending a GET request with no auth and receiving HTML in response */
+    public String getHtmlPublic(String uri, Object... uriVariables) {
+        return webClient.get().uri(uri, uriVariables)
+                .accept(MediaType.TEXT_HTML)
+                .exchange()
+                .expectStatus()
+                .is2xxSuccessful()
+                .expectBody(String.class)
+                .returnResult()
+                .getResponseBody();
+    }
 }

--- a/src/test/java/io/apimap/api/integration/IntegrationTestHelper.java
+++ b/src/test/java/io/apimap/api/integration/IntegrationTestHelper.java
@@ -77,7 +77,11 @@ class IntegrationTestHelper {
                 } catch (Exception e) {
                     System.err.println("Could not delete test API version: " + e);
                 }
-                // TODO: delete votes
+                try {
+                    voteRepository.delete(version.getApiId(), version.getVersion()).block();
+                } catch (Exception e) {
+                    System.err.println("Could not delete test votes: " + e);
+                }
             }
             apiRepository.delete(api.getName()).block();
         }

--- a/src/test/java/io/apimap/api/integration/SmokeTestAllBase.java
+++ b/src/test/java/io/apimap/api/integration/SmokeTestAllBase.java
@@ -203,4 +203,46 @@ public abstract class SmokeTestAllBase {
                 .ignoringFields("links", "uri")
                 .isEqualTo(metadataUpdate);
     }
+
+    @Test
+    public void testReadmeCrud() {
+        var testDoc = testData.createMarkdownDoc();
+        var docUpdate = "# NEW TITLE\n\nhello.";
+
+        var api = helper.storeApi(testData.createApiData());
+        var version = helper.storeVersionForCurrentApi(testData.createApiVersion());
+
+        var createResult = helper.postMarkdownAuthed(testDoc, "/api/{name}/version/{version}/readme", api.getName(), version.getVersion());
+        var updateResult = helper.putMarkdownAuthed(docUpdate, "/api/{name}/version/{version}/readme", api.getName(), version.getVersion());
+        var retrieveResult = helper.getMarkdownPublic("/api/{name}/version/{version}/readme", api.getName(), version.getVersion());
+        helper.deleteAuthedAndVerifyGone("/api/{name}/version/{version}/readme", api.getName(), version.getVersion());
+
+        assertThat(createResult).as("create result")
+                .isEqualTo(testDoc);
+        assertThat(updateResult).as("update result")
+                .isEqualTo(docUpdate);
+        assertThat(retrieveResult).as("get result")
+                .isEqualTo(docUpdate);
+    }
+
+    @Test
+    public void testChangelogCrud() {
+        var testDoc = testData.createMarkdownDoc();
+        var docUpdate = "# NEW TITLE\n\nhello.";
+
+        var api = helper.storeApi(testData.createApiData());
+        var version = helper.storeVersionForCurrentApi(testData.createApiVersion());
+
+        var createResult = helper.postMarkdownAuthed(testDoc, "/api/{name}/version/{version}/changelog", api.getName(), version.getVersion());
+        var updateResult = helper.putMarkdownAuthed(docUpdate, "/api/{name}/version/{version}/changelog", api.getName(), version.getVersion());
+        var retrieveResult = helper.getMarkdownPublic("/api/{name}/version/{version}/changelog", api.getName(), version.getVersion());
+        helper.deleteAuthedAndVerifyGone("/api/{name}/version/{version}/changelog", api.getName(), version.getVersion());
+
+        assertThat(createResult).as("create result")
+                .isEqualTo(testDoc);
+        assertThat(updateResult).as("update result")
+                .isEqualTo(docUpdate);
+        assertThat(retrieveResult).as("get result")
+                .isEqualTo(docUpdate);
+    }
 }

--- a/src/test/java/io/apimap/api/integration/SmokeTestAllBase.java
+++ b/src/test/java/io/apimap/api/integration/SmokeTestAllBase.java
@@ -1,6 +1,9 @@
 package io.apimap.api.integration;
 
 import io.apimap.api.rest.ApiDataRestEntity;
+import io.apimap.api.rest.ClassificationDataRestEntity;
+import io.apimap.api.rest.ClassificationRootRestEntity;
+import io.apimap.api.rest.MetadataDataRestEntity;
 import io.apimap.api.rest.jsonapi.JsonApiRestRequestWrapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -8,8 +11,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-import static io.apimap.api.integration.IntegrationTestHelper.RESPONSE_TYPE_API;
-import static io.apimap.api.integration.IntegrationTestHelper.RESPONSE_TYPE_API_LIST;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.apimap.api.integration.IntegrationTestHelper.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -42,7 +47,7 @@ public abstract class SmokeTestAllBase {
 
     /** test API lifecycle with POST, PUT, GET and DELETE */
     @Test
-    public void testApiCRUD() throws Exception {
+    public void testApiCrud() {
         var testApi = testData.createApiData();
         var apiUpdate = new ApiDataRestEntity(testApi.getName(), "http://example.org/new_repo");
 
@@ -87,5 +92,115 @@ public abstract class SmokeTestAllBase {
 
         assertThat(getResult.getData().getData())
                 .hasSize(1);
+    }
+
+    /** test API version lifecycle with POST, GET and DELETE */
+    @Test
+    public void testApiVersionCrd() {
+        var testApiVersion = testData.createApiVersion();
+
+        var api = helper.storeApi(testData.createApiData());
+
+        var createResult = helper.postJsonAuthed(RESPONSE_TYPE_VERSION, new JsonApiRestRequestWrapper<>(testApiVersion), "/api/{name}/version", api.getName());
+        var retrieveResult = helper.getJsonPublic(RESPONSE_TYPE_VERSION, "/api/{name}/version/{version}", api.getName(), testApiVersion.getVersion());
+        helper.deleteAuthedAndVerifyGone("/api/{name}/version/{version}", api.getName(), testApiVersion.getVersion());
+
+        assertThat(createResult.getData()).as("create result")
+                .usingRecursiveComparison()
+                .ignoringFields("created", "rating", "id")
+                .isEqualTo(testApiVersion);
+
+        assertThat(retrieveResult.getData()).as("get result")
+                .usingRecursiveComparison()
+                .isEqualTo(createResult.getData());
+    }
+
+    @Test
+    public void testGetAllApiVersions() {
+        var api = helper.storeApi(testData.createApiData());
+        helper.storeVersionForCurrentApi(testData.createApiVersion());
+
+        var getResult = helper.getJsonPublic(RESPONSE_TYPE_VERSION_LIST, "/api/{name}/version", api.getName());
+
+        assertThat(getResult.getData().getVersions())
+                .hasSize(1);
+    }
+
+    @Test
+    public void testClassificationCrud() {
+        var testClassifications = new ClassificationRootRestEntity(new ArrayList<>(List.of(
+                testData.createClassification("taxonomy://what"),
+                testData.createClassification("taxonomy://who")
+        )));
+        var classificationsUpdate = new ClassificationRootRestEntity(new ArrayList<>(List.of(
+                testData.createClassification("taxonomy://what"),
+                testData.createClassification("taxonomy://where")
+        )));
+
+        var api = helper.storeApi(testData.createApiData());
+        var version = helper.storeVersionForCurrentApi(testData.createApiVersion());
+
+        var createResult = helper.postJsonAuthed(RESPONSE_TYPE_CLASSIFICATION_LIST, new JsonApiRestRequestWrapper<>(testClassifications), "/api/{name}/version/{version}/classification", api.getName(), version.getVersion());
+        var updateResult = helper.putJsonAuthed(RESPONSE_TYPE_CLASSIFICATION_LIST, new JsonApiRestRequestWrapper<>(classificationsUpdate), "/api/{name}/version/{version}/classification", api.getName(), version.getVersion());
+        var retrieveResult = helper.getJsonPublic(RESPONSE_TYPE_CLASSIFICATION_LIST, "/api/{name}/version/{version}/classification", api.getName(), version.getVersion());
+        helper.deleteAuthed("/api/{name}/version/{version}/classification", api.getName(), version.getVersion());
+        // GET after DELETE returns an empty list of classifications
+        var retrieveAfterDelete = helper.getJsonPublic(RESPONSE_TYPE_CLASSIFICATION_LIST, "/api/{name}/version/{version}/classification", api.getName(), version.getVersion());
+
+        assertThat(createResult.getData()).as("create result")
+                .usingRecursiveComparison()
+                .isEqualTo(testClassifications);
+
+        assertThat(updateResult.getData()).as("update result")
+                .usingRecursiveComparison()
+                .isEqualTo(classificationsUpdate);
+
+        assertThat(retrieveResult.getData()).as("get result")
+                .usingRecursiveComparison()
+                .isEqualTo(classificationsUpdate);
+
+        assertThat(retrieveAfterDelete.getData().getData()).as("get after delete")
+                .isEmpty();
+    }
+
+    @Test
+    public void testMetadataCrud() {
+        var testMetadata = testData.createMetadata();
+        var metadataUpdate = new MetadataDataRestEntity(
+                testMetadata.getName(),
+                "new description",
+                "new visibility",
+                testMetadata.getApiVersion(),
+                "new release status",
+                "new interface",
+                "new description language",
+                "new layer",
+                "new unit",
+                "new system identifier",
+                List.of("https://example.org/new_documentation")
+        );
+
+        var api = helper.storeApi(testData.createApiData());
+        var version = helper.storeVersionForCurrentApi(testData.createApiVersion());
+
+        var createResult = helper.postJsonAuthed(RESPONSE_TYPE_METADATA, new JsonApiRestRequestWrapper<>(testMetadata), "/api/{name}/version/{version}/metadata", api.getName(), version.getVersion());
+        var updateResult = helper.putJsonAuthed(RESPONSE_TYPE_METADATA, new JsonApiRestRequestWrapper<>(metadataUpdate), "/api/{name}/version/{version}/metadata", api.getName(), version.getVersion());
+        var retrieveResult = helper.getJsonPublic(RESPONSE_TYPE_METADATA, "/api/{name}/version/{version}/metadata", api.getName(), version.getVersion());
+        helper.deleteAuthedAndVerifyGone("/api/{name}/version/{version}/metadata", api.getName(), version.getVersion());
+
+        assertThat(createResult.getData()).as("create result")
+                .usingRecursiveComparison()
+                .ignoringFields("links", "uri")
+                .isEqualTo(testMetadata);
+
+        assertThat(updateResult.getData()).as("update result")
+                .usingRecursiveComparison()
+                .ignoringFields("links", "uri")
+                .isEqualTo(metadataUpdate);
+
+        assertThat(retrieveResult.getData()).as("get result")
+                .usingRecursiveComparison()
+                .ignoringFields("links", "uri")
+                .isEqualTo(metadataUpdate);
     }
 }

--- a/src/test/java/io/apimap/api/integration/SmokeTestAllBase.java
+++ b/src/test/java/io/apimap/api/integration/SmokeTestAllBase.java
@@ -1,9 +1,6 @@
 package io.apimap.api.integration;
 
-import io.apimap.api.rest.ApiDataRestEntity;
-import io.apimap.api.rest.ClassificationDataRestEntity;
-import io.apimap.api.rest.ClassificationRootRestEntity;
-import io.apimap.api.rest.MetadataDataRestEntity;
+import io.apimap.api.rest.*;
 import io.apimap.api.rest.jsonapi.JsonApiRestRequestWrapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -244,5 +241,27 @@ public abstract class SmokeTestAllBase {
                 .isEqualTo(docUpdate);
         assertThat(retrieveResult).as("get result")
                 .isEqualTo(docUpdate);
+    }
+
+    @Test
+    public void testVoting() {
+        var testVote = new VoteDataRestEntity(4);
+
+        var api = helper.storeApi(testData.createApiData());
+        var version = helper.storeVersionForCurrentApi(testData.createApiVersion());
+
+        var voteResult = helper.postJsonAuthed(RESPONSE_TYPE_VOTE, new JsonApiRestRequestWrapper<>(testVote), "/api/{name}/version/{version}/vote", api.getName(), version.getVersion());
+        var retrieveResult = helper.getJsonPublic(RESPONSE_TYPE_VOTE_LIST, "/api/{name}/version/{version}/vote", api.getName(), version.getVersion());
+
+        assertThat(voteResult.getData()).as("create result")
+                .usingRecursiveComparison()
+                .ignoringFields()
+                .isEqualTo(testVote);
+
+        assertThat(retrieveResult.getData().getData()).as("get votes")
+                .hasSize(1);
+        assertThat(retrieveResult.getData().getData().get(0)).as("stored vote")
+                .usingRecursiveComparison()
+                .isEqualTo(testVote);
     }
 }

--- a/src/test/java/io/apimap/api/integration/SmokeTestApiRoutesBase.java
+++ b/src/test/java/io/apimap/api/integration/SmokeTestApiRoutesBase.java
@@ -15,9 +15,9 @@ import static io.apimap.api.integration.IntegrationTestHelper.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Base test class with common test cases that should work both when using NitriteDB and MongoDB
+ * Base test class with common test cases for API that should work both when using NitriteDB and MongoDB
  */
-public abstract class SmokeTestAllBase {
+public abstract class SmokeTestApiRoutesBase {
 
 
     private final TestDataHelper testData = new TestDataHelper();

--- a/src/test/java/io/apimap/api/integration/SmokeTestApiRoutesBase.java
+++ b/src/test/java/io/apimap/api/integration/SmokeTestApiRoutesBase.java
@@ -244,6 +244,20 @@ public abstract class SmokeTestApiRoutesBase {
     }
 
     @Test
+    public void testRenderedChangelog() {
+        var testDoc = "# Title\n\ndescription";
+
+        var api = helper.storeApi(testData.createApiData());
+        var version = helper.storeVersionForCurrentApi(testData.createApiVersion());
+
+        helper.postMarkdownAuthed(testDoc, "/api/{name}/version/{version}/changelog", api.getName(), version.getVersion());
+
+        var renderedResponse = helper.getHtmlPublic("/api/{name}/version/{version}/changelog", api.getName(), version.getVersion());
+        assertThat(renderedResponse)
+                .contains("<h1>Title</h1>");
+    }
+
+    @Test
     public void testVoting() {
         var testVote = new VoteDataRestEntity(4);
 
@@ -263,5 +277,19 @@ public abstract class SmokeTestApiRoutesBase {
         assertThat(retrieveResult.getData().getData().get(0)).as("stored vote")
                 .usingRecursiveComparison()
                 .isEqualTo(testVote);
+    }
+
+    @Test
+    public void testRenderedReadme() {
+        var testDoc = "# Title\n\ndescription";
+
+        var api = helper.storeApi(testData.createApiData());
+        var version = helper.storeVersionForCurrentApi(testData.createApiVersion());
+        helper.postMarkdownAuthed(testDoc, "/api/{name}/version/{version}/readme", api.getName(), version.getVersion());
+
+        var renderedResponse = helper.getHtmlPublic("/api/{name}/version/{version}/readme", api.getName(), version.getVersion());
+
+        assertThat(renderedResponse)
+                .contains("<h1>Title</h1>");
     }
 }

--- a/src/test/java/io/apimap/api/integration/SmokeTestApiRoutesWithNitriteIT.java
+++ b/src/test/java/io/apimap/api/integration/SmokeTestApiRoutesWithNitriteIT.java
@@ -7,14 +7,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 
 /**
- * Run smoke tests with the Nitrite database implementations
+ * Run API smoke tests with the Nitrite database implementations
  */
 @SpringBootTest
 @AutoConfigureWebTestClient
 @Import(NitriteTestConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class SmokeTestAllWithNitriteIT extends SmokeTestAllBase {
+public class SmokeTestApiRoutesWithNitriteIT extends SmokeTestApiRoutesBase {
 
-    // Runs tests from the SmokeTestAllBase base class
+    // Runs tests from the SmokeTestApiRoutesBase base class
 
 }

--- a/src/test/java/io/apimap/api/integration/TestDataHelper.java
+++ b/src/test/java/io/apimap/api/integration/TestDataHelper.java
@@ -2,7 +2,6 @@ package io.apimap.api.integration;
 
 import io.apimap.api.rest.*;
 
-import java.util.Date;
 import java.util.List;
 
 /** Helper to generate dummy test data */
@@ -40,5 +39,9 @@ public class TestDataHelper {
                 urn,
                 "1"
         );
+    }
+
+    public String createMarkdownDoc() {
+        return "Title\n=====\nLorem ipsum *dolor* sit amet.";
     }
 }

--- a/src/test/java/io/apimap/api/integration/TestDataHelper.java
+++ b/src/test/java/io/apimap/api/integration/TestDataHelper.java
@@ -1,9 +1,6 @@
 package io.apimap.api.integration;
 
-import io.apimap.api.rest.ApiDataRestEntity;
-import io.apimap.api.rest.ApiVersionDataRestEntity;
-import io.apimap.api.rest.ApiVersionRatingEntity;
-import io.apimap.api.rest.MetadataDataRestEntity;
+import io.apimap.api.rest.*;
 
 import java.util.Date;
 import java.util.List;
@@ -18,12 +15,7 @@ public class TestDataHelper {
     }
 
     public ApiVersionDataRestEntity createApiVersion() {
-        return new ApiVersionDataRestEntity(
-                "v1.1",
-                new Date(),
-                new ApiVersionRatingEntity(5),
-                "https://example.org/my-api/v1"
-        );
+        return new ApiVersionDataRestEntity("v1.1");
     }
 
     public MetadataDataRestEntity createMetadata() {
@@ -40,6 +32,13 @@ public class TestDataHelper {
                 "S19999",
                 List.of("https://example.org/README.txt"),
                 "https://example.org/api"
+        );
+    }
+
+    public ClassificationDataRestEntity createClassification(String urn) {
+        return new ClassificationDataRestEntity(
+                urn,
+                "1"
         );
     }
 }


### PR DESCRIPTION
Expand smoke test coverage to cover all handlers registered in ApiRouter.

Includes a couple of small fixes to metadata update and zip download to make the tests pass.