### PR TITLE
test(integration): Run smoke tests with MongoDB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.4'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.4.11'
 }
 
 bootRun {

--- a/src/main/java/io/apimap/api/Application.java
+++ b/src/main/java/io/apimap/api/Application.java
@@ -32,6 +32,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoReactiveAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
@@ -49,11 +50,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
                 @Tag(name = "START", description = "The HATEOAS start point for exploring the API")
         }
 )
-@SpringBootApplication
-@EnableAutoConfiguration(exclude = {
+@SpringBootApplication(exclude = {
         MongoAutoConfiguration.class,
         MongoDataAutoConfiguration.class,
-        MongoReactiveAutoConfiguration.class
+        MongoReactiveAutoConfiguration.class,
+        EmbeddedMongoAutoConfiguration.class,
 })
 @EnableConfigurationProperties({ApimapConfiguration.class, NitriteConfiguration.class})
 public class Application {

--- a/src/test/java/io/apimap/api/integration/SmokeTestApiRoutesBase.java
+++ b/src/test/java/io/apimap/api/integration/SmokeTestApiRoutesBase.java
@@ -12,6 +12,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.zip.ZipEntry;
@@ -187,6 +188,11 @@ public abstract class SmokeTestApiRoutesBase {
         helper.deleteAuthed("/api/{name}/version/{version}/classification", api.getName(), version.getVersion());
         // GET after DELETE returns an empty list of classifications
         var retrieveAfterDelete = helper.getJsonPublic(RESPONSE_TYPE_CLASSIFICATION_LIST, "/api/{name}/version/{version}/classification", api.getName(), version.getVersion());
+
+        // Classification order is not always stable, sort result to be sure
+        createResult.getData().getData().sort(Comparator.comparing(ClassificationDataRestEntity::getUrn));
+        updateResult.getData().getData().sort(Comparator.comparing(ClassificationDataRestEntity::getUrn));
+        retrieveResult.getData().getData().sort(Comparator.comparing(ClassificationDataRestEntity::getUrn));
 
         assertThat(createResult.getData()).as("create result")
                 .usingRecursiveComparison()

--- a/src/test/java/io/apimap/api/integration/SmokeTestApiRoutesWithMongoDbIT.java
+++ b/src/test/java/io/apimap/api/integration/SmokeTestApiRoutesWithMongoDbIT.java
@@ -1,0 +1,21 @@
+package io.apimap.api.integration;
+
+import io.apimap.api.integration.dbconfig.MongoDbTestConfig;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Run API smoke tests with an embedded MongoDB database
+ */
+@SpringBootTest(properties = {"nitrite.enabled=false", "mongodb.enabled=true"})
+@AutoConfigureWebTestClient
+@Import({MongoDbTestConfig.class, EmbeddedMongoAutoConfiguration.class})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SmokeTestApiRoutesWithMongoDbIT extends SmokeTestApiRoutesBase {
+
+    // Runs tests from the SmokeTestApiRoutesBase base class
+
+}

--- a/src/test/java/io/apimap/api/integration/dbconfig/MongoDbTestConfig.java
+++ b/src/test/java/io/apimap/api/integration/dbconfig/MongoDbTestConfig.java
@@ -1,0 +1,65 @@
+package io.apimap.api.integration.dbconfig;
+
+import com.mongodb.reactivestreams.client.MongoClient;
+import de.flapdoodle.embed.mongo.config.MongodConfig;
+import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import io.apimap.api.configuration.MongoConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+
+import java.io.IOException;
+
+/**
+ * MongoDB configuration for tests - provides config for the EmbeddedMongoAutoConfiguration
+ * to start an in-memory MongoDB server for the test, and overrides the beans from our MongoConfiguration class.
+ */
+@TestConfiguration
+public class MongoDbTestConfig {
+
+    // Keep our own copy of MongoConfiguration so we can set the connection URI based on the test mongodb instance
+    private final MongoConfiguration substituteConfig = new MongoConfiguration();
+
+    /**
+     * Configuration for the MongoDB embedded server
+     *
+     * @see org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
+     */
+    @Bean
+    public MongodConfig mongodConfig() {
+        try {
+            var netConfig = new Net();
+            var database = "apimap";
+            var uri = String.format("mongodb://%s:%d/%s", netConfig.getServerAddress().getHostAddress(), netConfig.getPort(), database);
+
+            substituteConfig.setUri(uri);
+            substituteConfig.setDatabaseName(database);
+
+            return MongodConfig.builder()
+                    .version(Version.V3_6_22)
+                    .net(netConfig)
+                    .build();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Override MongoConfiguration.reactiveMongoClient */
+    @Bean
+    @Primary
+    @DependsOn("mongodConfig")
+    public MongoClient reactiveMongoClientForTest() {
+        return substituteConfig.reactiveMongoClient();
+    }
+
+    /** Override MongoConfiguration.reactiveMongoTemplate */
+    @Bean
+    @Primary
+    @DependsOn("mongodConfig")
+    public ReactiveMongoTemplate reactiveMongoTemplateForTest() {
+        return substituteConfig.reactiveMongoTemplate();
+    }
+}


### PR DESCRIPTION
Run smoke tests with a MongoDB instance provided by the Embedded MongoDB jar from FlapDoodle.
Spring Boot supports this pretty much out of the box - we even have to add an exclusion to not start by default for all tests.