### PR TITLE
chore(ci): fix GitHub CI deprecation warnings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,11 +8,11 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 16
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '16'
           distribution: 'zulu'

--- a/.github/workflows/buildandpublish.yaml
+++ b/.github/workflows/buildandpublish.yaml
@@ -8,11 +8,11 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 16
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '16'
           distribution: 'zulu'
@@ -30,24 +30,24 @@ jobs:
           MULTI_PACKAGES_USER: ${{ secrets.MULTI_PACKAGES_USER }}
       - name: Read release tag
         id: read_tag
-        run: echo "::set-output name=release_tag::$(git tag --points-at HEAD 'v[0-9]*' | head -n1)"
+        run: echo "release_tag=$(git tag --points-at HEAD 'v[0-9]*' | head -n1)" >> $GITHUB_OUTPUT
       - name: Login to Docker Hub
         if: ${{ steps.read_tag.outputs.release_tag != '' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       - name: Set up Docker Buildx
         if: ${{ steps.read_tag.outputs.release_tag != '' }}
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Unpack
         if: ${{ steps.read_tag.outputs.release_tag != '' }}
         run: mkdir -p build/dependency && (cd build/dependency; cp ../libs/api-complete.jar .; jar -xf api-complete.jar)
       - name: Build and push
         if: ${{ steps.read_tag.outputs.release_tag != '' }}
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
         language: [ 'java' ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Initialize CodeQL
@@ -32,7 +32,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
       - name: Set up JDK 16
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '16'
           distribution: 'zulu'


### PR DESCRIPTION
Bump action versions and rewrite a use of '::set-output' to avoid the following deprecation warnings:

 - Node.js 12 actions are deprecated.
 - The `save-state` command is deprecated and will be disabled soon.
 - The `set-output` command is deprecated and will be disabled soon.

See:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/